### PR TITLE
Remove Hard Node Version Requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "bin": {
     "mlb": "./bin/mlb"
   },
-  "engines": {
-    "node": "4.4.2"
-  },
   "preferGlobal": true,
   "dependencies": {
     "cli-table": "^0.3.1",


### PR DESCRIPTION
This removed the hard requirement for Node version 4.4.2. Omitting the engine, will assume that this package works will all versions of Node. An alternative is to add a minimum version.