### PR TITLE
Thu 12 Apr 2018 12:02:51 EDT Display multiple 'single' tables per game

### DIFF
--- a/bin/mlb
+++ b/bin/mlb
@@ -25,5 +25,8 @@ switch (true) {
   break;
   default:
     mlb();
+    setInterval(function () {
+      mlb();
+    }, 60000);
   break;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "mlbscores",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+    },
+    "cli-table": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+      "requires": {
+        "colors": "1.0.3"
+      }
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    },
+    "gameday-helper": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/gameday-helper/-/gameday-helper-0.1.1.tgz",
+      "integrity": "sha1-1qBAHUs6C1Gn/Z/D/zENuh6LmGI=",
+      "requires": {
+        "bluebird": "2.11.0",
+        "underscore": "1.8.3"
+      }
+    },
+    "moment": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "mlb": "./bin/mlb"
   },
+  "engines": {
+    "node": "4.4.2"
+  },
   "preferGlobal": true,
   "dependencies": {
     "cli-table": "^0.3.1",
@@ -13,7 +16,9 @@
     "moment": "^2.12.0"
   },
   "devDependencies": {},
-  "scripts": {},
+  "scripts": {
+    "dev": "./bin/mlb"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ryanburgess/mlb-cli.git"


### PR DESCRIPTION
Hey @ryanburgess as an avid baseball fan, i am submitting the following pull request


## One Table Per Game - Feature
> Broke the single table layout into a table per game similar to 
[Googling 'MLB'](https://www.google.ca/search?q=mlb)

### Dynamic Layout
> Based on the width and height of the terminal window
> process.stdout.columns & process.stdout.row
> output appropriate layout

#### 4 column
<img width="1788" alt="screen shot 2018-04-12 at 11 55 15 am" src="https://user-images.githubusercontent.com/75797/38689751-69c1554e-3e4a-11e8-806b-d7233ac02ec5.png">

#### 3 column
<img width="1207" alt="screen shot 2018-04-12 at 11 55 30 am" src="https://user-images.githubusercontent.com/75797/38689752-69d085e6-3e4a-11e8-9399-106d74c35093.png">

#### 2 column
<img width="857" alt="screen shot 2018-04-12 at 11 55 53 am" src="https://user-images.githubusercontent.com/75797/38689753-69e0db26-3e4a-11e8-9d6a-6dfc6081d3fc.png">

#### 1 column
<img width="507" alt="screen shot 2018-04-12 at 11 56 17 am" src="https://user-images.githubusercontent.com/75797/38689754-6a183922-3e4a-11e8-9f78-02867aeb5fcf.png">

## Bonus
> Interval
As an individual with terminal on top always, there is now a 1 minute interval that clears the terminal and repaints latest box scores

